### PR TITLE
fs: drop OAuth hash params instead of treating them as a path

### DIFF
--- a/src/pages/FsPage.jsx
+++ b/src/pages/FsPage.jsx
@@ -84,8 +84,13 @@ export default function FsPage() {
   const bootedRef = useRef(false);   // guards StrictMode double-fire on the bootstrap effect
 
   const initialCwd = useMemo(() => {
-    const raw = decodeURIComponent(loc.hash.slice(1) || "/");
-    return normalizePath(raw);
+    const rawHash = loc.hash.slice(1);
+    // supabase OAuth dumps `#access_token=...&...` on return — never a path.
+    if (!rawHash || /(^|&)(access_token|error|provider_token|refresh_token)=/.test(rawHash)) {
+      if (rawHash) window.history.replaceState(null, "", window.location.pathname + window.location.search);
+      return "/";
+    }
+    return normalizePath(decodeURIComponent(rawHash));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [cwd, setCwd] = useState("/");


### PR DESCRIPTION
After GitHub sign-in Supabase appends \`#access_token=…&refresh_token=…\` etc. to the return URL. The /fs deep-link logic was reading the hash as an initial directory and running \`cd /access_token=…\` — which was the \"cd: no such directory\" error you just hit.

Now we detect any of the OAuth payload keys (\`access_token\`, \`error\`, \`provider_token\`, \`refresh_token\`) and clear the hash via \`history.replaceState\`, so the URL bar is also clean.

## Test plan
- [ ] Sign out, click \`signin\`, return — terminal lands at \`/\`, no error, hash gone from URL
- [ ] Deep links still work: visiting \`https://nilsmatteson.com/fs#/home/matteso1\` cd's into that dir
- [ ] \`npm test\` passes (26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)