### PR TITLE
fs: stop racing supabase for the OAuth hash

### DIFF
--- a/src/lib/useAuth.js
+++ b/src/lib/useAuth.js
@@ -20,7 +20,7 @@ export function useAuth() {
   }, []);
 
   const signInWithGitHub = (redirectPath) => {
-    if (!isSupabaseConfigured) return;
+    if (!isSupabaseConfigured) return Promise.resolve({ data: null, error: { message: "supabase not configured" } });
     const back = redirectPath || (window.location.pathname + window.location.hash);
     return supabase.auth.signInWithOAuth({
       provider: "github",

--- a/src/pages/FsPage.jsx
+++ b/src/pages/FsPage.jsx
@@ -84,8 +84,13 @@ export default function FsPage() {
   const bootedRef = useRef(false);   // guards StrictMode double-fire on the bootstrap effect
 
   const initialCwd = useMemo(() => {
-    const raw = decodeURIComponent(loc.hash.slice(1) || "/");
-    return normalizePath(raw);
+    const rawHash = loc.hash.slice(1);
+    // supabase OAuth dumps `#access_token=...&...` on return — never a path.
+    if (!rawHash || /(^|&)(access_token|error|provider_token|refresh_token)=/.test(rawHash)) {
+      if (rawHash) window.history.replaceState(null, "", window.location.pathname + window.location.search);
+      return "/";
+    }
+    return normalizePath(decodeURIComponent(rawHash));
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [cwd, setCwd] = useState("/");

--- a/src/pages/FsPage.jsx
+++ b/src/pages/FsPage.jsx
@@ -86,8 +86,9 @@ export default function FsPage() {
   const initialCwd = useMemo(() => {
     const rawHash = loc.hash.slice(1);
     // supabase OAuth dumps `#access_token=...&...` on return — never a path.
+    // do NOT strip the hash here — supabase reads it asynchronously to establish
+    // the session, and will clean the URL itself once it's done.
     if (!rawHash || /(^|&)(access_token|error|provider_token|refresh_token)=/.test(rawHash)) {
-      if (rawHash) window.history.replaceState(null, "", window.location.pathname + window.location.search);
       return "/";
     }
     return normalizePath(decodeURIComponent(rawHash));

--- a/src/pages/FsPage.jsx
+++ b/src/pages/FsPage.jsx
@@ -188,7 +188,16 @@ export default function FsPage() {
         case "signin": case "login": {
           if (user) { push("dim", `already signed in as ${handle}`); break; }
           push("dim", "redirecting to github…");
-          signInWithGitHub("/fs");
+          try {
+            const res = await signInWithGitHub("/fs");
+            if (res?.error) {
+              push("err", `signin failed: ${res.error.message}`);
+            } else if (res?.data?.url) {
+              window.location.assign(res.data.url);
+            }
+          } catch (e) {
+            push("err", `signin failed: ${e.message || e}`);
+          }
           break;
         }
 


### PR DESCRIPTION
PR #4 used \`history.replaceState\` to clear the \`#access_token=…\` fragment from the URL after OAuth. That ran synchronously during render — **before** supabase-js's async \`detectSessionInUrl\` had a chance to read it. Supabase woke up, found an empty hash, and silently failed to persist the session.

The user-visible bug: signing in *appeared* to work (GitHub round-trip happened), but the prompt stayed at \`guest@…\`. Running \`signin\` again invisibly redirected to GitHub, which auto-approved (no UI shown), bounced back, and again silently failed. From the user's perspective, \`signin\` did nothing.

Fix: leave the hash alone. Supabase reads it, persists the session, then cleans the URL itself. We still don't try to \`cd\` into OAuth fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)