### PR TITLE
fs: stop racing supabase for the OAuth hash

### DIFF
--- a/src/pages/FsPage.jsx
+++ b/src/pages/FsPage.jsx
@@ -86,8 +86,9 @@ export default function FsPage() {
   const initialCwd = useMemo(() => {
     const rawHash = loc.hash.slice(1);
     // supabase OAuth dumps `#access_token=...&...` on return — never a path.
+    // do NOT strip the hash here — supabase reads it asynchronously to establish
+    // the session, and will clean the URL itself once it's done.
     if (!rawHash || /(^|&)(access_token|error|provider_token|refresh_token)=/.test(rawHash)) {
-      if (rawHash) window.history.replaceState(null, "", window.location.pathname + window.location.search);
       return "/";
     }
     return normalizePath(decodeURIComponent(rawHash));


### PR DESCRIPTION
PR #4 used \`history.replaceState\` to clear the \`#access_token=…\` fragment from the URL after OAuth. That ran synchronously during render — **before** supabase-js's async \`detectSessionInUrl\` had a chance to read it. Supabase woke up, found an empty hash, and silently failed to persist the session.

User-visible bug: signing in *appeared* to work (GitHub round-trip happened), but the prompt stayed at \`guest@…\`. Running \`signin\` again invisibly redirected to GitHub, which auto-approved (no UI shown), bounced back, and again silently failed. From the user's perspective, \`signin\` did nothing.

Fix: leave the hash alone. Supabase reads it, persists the session, then cleans the URL itself. We still don't try to \`cd\` into OAuth fragments.

(Replaces #6 which had a stale-base conflict.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)