### PR TITLE
fs: fix :wq + sweep adjacent bugs

### DIFF
--- a/src/components/VimModal.jsx
+++ b/src/components/VimModal.jsx
@@ -48,14 +48,27 @@ export default function VimModal() {
     return () => window.removeEventListener("vim:open", onOpen);
   }, []);
 
-  // unified key handler — runs even when the textarea has focus,
-  // because in NORMAL the textarea is readOnly so ":" wouldn't insert anyway.
+  // mode + readonly mirrored to refs so the keydown closure always sees the
+  // live value without depending on effect re-registration (which would
+  // otherwise lag a render behind real keystrokes).
+  const modeRef = useRef("NORMAL");
+  const readonlyRef = useRef(false);
+  useEffect(() => { modeRef.current = mode; }, [mode]);
+  useEffect(() => { readonlyRef.current = readonly; }, [readonly]);
+
+  // unified key handler — capture phase + stopImmediatePropagation when we
+  // own a keystroke, so global listeners (e.g. CommandPalette's `:` trigger)
+  // can't double-handle the same event while the modal is up.
   useEffect(() => {
     if (!open) return;
     const onKey = (e) => {
+      const m = modeRef.current;
+      const ro = readonlyRef.current;
+
       if (e.key === "Escape") {
         e.preventDefault();
-        if (mode !== "NORMAL") {
+        e.stopImmediatePropagation();
+        if (m !== "NORMAL") {
           setMode("NORMAL");
           setCmd("");
           setStatus("");
@@ -68,31 +81,40 @@ export default function VimModal() {
       const tag = (e.target.tagName || "").toLowerCase();
       const inField = tag === "textarea" || tag === "input";
 
-      if (mode === "NORMAL") {
-        if (e.key === "i" && !readonly) {
+      if (m === "NORMAL") {
+        if (e.key === "i" && !ro) {
           e.preventDefault();
+          e.stopImmediatePropagation();
           setMode("INSERT");
           setStatus("-- INSERT --");
         } else if (e.key === ":") {
           e.preventDefault();
+          e.stopImmediatePropagation();
           setMode("COMMAND");
           setCmd("");
           setStatus("");
-        } else if (e.key === "q" && readonly) {
+        } else if (e.key === "q" && ro) {
           e.preventDefault();
+          e.stopImmediatePropagation();
           close();
-        } else if (e.key === "ZZ") {
-          // unreachable; placeholder for future Z Z mapping
+        } else if (e.key === "/" || e.key === "?") {
+          // swallow palette triggers while modal is open; we don't have search yet
+          e.preventDefault();
+          e.stopImmediatePropagation();
         }
         return;
       }
 
-      // INSERT / COMMAND — let the active field handle keystrokes
-      if (inField) return;
+      // INSERT / COMMAND — let the active field handle keystrokes, but block
+      // global hotkeys (CommandPalette, etc.) from racing it.
+      if (inField) {
+        e.stopPropagation();
+        return;
+      }
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [open, mode, readonly]);
+  }, [open]);
 
   // focus per-mode
   useEffect(() => {

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -51,10 +51,6 @@ function invalidateIndex() {
   _indexAt = 0;
 }
 
-if (typeof window !== "undefined") {
-  window.addEventListener("vim:saved", invalidateIndex);
-}
-
 export async function listAll({ force = false } = {}) {
   if (!isSupabaseConfigured) return [];
   const fresh = _indexCache && Date.now() - _indexAt < INDEX_TTL_MS;
@@ -125,8 +121,12 @@ export async function writeFile({ path, content }) {
   if (!content || !content.trim()) throw new Error("E: empty buffer");
   if (content.length > 4096) throw new Error(`E: file too large (${content.length}/4096)`);
 
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error("E: not signed in (run `signin` to write files)");
+  // getSession reads the cached session — no network call, no race with the
+  // post-OAuth state restore. (getUser would round-trip to /auth/v1/user and
+  // can return null briefly right after the OAuth redirect lands.)
+  const { data: { session } } = await supabase.auth.getSession();
+  const sessionUser = session?.user;
+  if (!sessionUser) throw new Error("E: not signed in (run `signin` to write files)");
 
   const { data, error } = await supabase
     .from("fs_files")
@@ -136,7 +136,8 @@ export async function writeFile({ path, content }) {
   if (error) {
     if (error.code === "23505") throw new Error(`E: ${p} already exists`);
     if (error.code === "42501" || /row-level security/i.test(error.message)) {
-      throw new Error(`E: write denied — your home is /home/${(user.user_metadata?.user_name || "").toLowerCase()}/`);
+      const handle = (sessionUser.user_metadata?.user_name || "").toLowerCase();
+      throw new Error(`E: write denied — your home is /home/${handle}/`);
     }
     throw new Error(error.message || "write failed");
   }

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -10,6 +10,6 @@ export const ADMIN_GITHUB_USERNAME = "matteso1";
 
 export function isAdmin(user) {
   if (!user) return false;
-  const username = user.user_metadata?.user_name || user.user_metadata?.preferred_username;
+  const username = (user.user_metadata?.user_name || user.user_metadata?.preferred_username || "").toLowerCase();
   return username === ADMIN_GITHUB_USERNAME;
 }

--- a/src/pages/FsPage.jsx
+++ b/src/pages/FsPage.jsx
@@ -117,11 +117,11 @@ export default function FsPage() {
       push("err", "filesystem offline (supabase not configured).");
       return;
     }
-    // pre-fetch the index so the first `ls` is instant
-    listAll().catch(() => {});
-    if (initialCwd && initialCwd !== "/") {
-      // if it points at a file, cat it; else cd + ls
-      (async () => {
+    // pre-fetch the index so the first `ls` is instant; deep-link processing
+    // must wait on it so `cd` sees the populated index.
+    (async () => {
+      try { await listAll(); } catch {}
+      if (initialCwd && initialCwd !== "/") {
         const f = await readFile(initialCwd);
         if (f) {
           await execute(`cat ${initialCwd}`, "/", true);
@@ -129,8 +129,8 @@ export default function FsPage() {
           await execute(`cd ${initialCwd}`, "/", true);
           await execute(`ls`, initialCwd, true);
         }
-      })();
-    }
+      }
+    })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -259,6 +259,9 @@ export default function FsPage() {
           // reject if it's a file
           const f = await readFile(target);
           if (f) { push("err", `cd: not a directory: ${target}`); break; }
+          // your own home always exists once signed in, even if empty
+          const myHome = user && handle !== "guest" ? `/home/${handle}` : null;
+          if (target === myHome || target === "/home") { setCwd(target); break; }
           // does any path live under it?
           const all = await listAll();
           const prefix = target + "/";


### PR DESCRIPTION
Spawned a thorough audit agent over the /fs feature. The reported \`:wq\` bug had a different root cause than I'd been guessing — and the audit surfaced four other real issues. Bundling them so we don't ship one PR per bug.

## Why \`:wq\` did nothing

\`CommandPalette\` registers a global \`keydown\` listener on the bubble phase that opens itself on \`:\`. \`VimModal\`'s capture-phase listener handled \`:\` first (correctly entering COMMAND mode) but didn't \`stopPropagation\`. The event continued to bubble, palette opened, palette's input grabbed focus on its own \`requestAnimationFrame\`, and the user's subsequent \`wq\` typed into the palette — which produced \`E492: Not an editor command\` and never reached the vim writeFile path.

## Fixes

### VimModal (\`src/components/VimModal.jsx\`)
- mode/readonly mirrored to refs; the keydown closure reads from refs so it always sees live values without depending on effect re-registration
- \`stopImmediatePropagation\` when handling NORMAL-mode keys (\`:\` \`i\` \`q\` \`/\` \`ESC\`)
- INSERT/COMMAND branch \`stopPropagation\`s typing in-field, so global hotkeys can't double-handle

### fs.js (\`writeFile\`)
- \`getSession\` instead of \`getUser\`: reads the cached session, no \`/auth/v1/user\` round-trip, no race with the post-OAuth state restore that could make a fast \`:wq\` fail with \"not signed in\"
- dropped the duplicate module-level \`vim:saved\` listener (FsPage already does this and the module-level one survives HMR)

### supabase.js (\`isAdmin\`)
- lowercase the GitHub username before comparing, so admins with any uppercase chars in their handle still flag as admin client-side (server already lowercases)

### FsPage.jsx
- \`cd\` into your own \`/home/<handle>\` works the moment you're signed in, even before writing your first file
- boot deep-link awaits \`listAll()\` before issuing \`cd\`, so the first navigation sees the warm index

## Test plan
- [ ] Sign in, \`vim ~/hello.txt\`, \`i\`, type, ESC, \`:wq\` — saves, prompt returns, no palette popup, \`ls /home/<you>\` shows the file
- [ ] Without writing anything, \`cd ~\` succeeds and prompt shows \`/home/<you>\`
- [ ] Reload at \`/fs#/home/<someone>\` lands cleanly (no \"no such directory\" flash)
- [ ] \`signin\` while already signed in still says \"already signed in\"
- [ ] \`npm test\` passes (26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)